### PR TITLE
update to match Exportfromtkb script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+input/
+output/
+saxon9he.jar
+SaxonHE9-9-0-1J/

--- a/page2tei_TU.xsl
+++ b/page2tei_TU.xsl
@@ -39,28 +39,28 @@
                         <title><xsl:value-of select="p:Metadata/temp:title"/><xsl:choose>
                             <xsl:when test="p:Page">, page <xsl:value-of select="p:Metadata/temp:pagenumber"/></xsl:when>
                         </xsl:choose> - Transcription</title>
-                        <!-- Time Us -->
+                        <!-- custom -->
                         <editor>Manuela Martini</editor>
-                        <!-- fin Time Us -->
+                        <!-- end custom -->
                         <respStmt><name><xsl:value-of select="p:Metadata/temp:uploader"/></name>, <resp>créateur⋅rice du document Transkribus (TRP).</resp></respStmt>
                     </titleStmt>
                     <publicationStmt>
-                        <!-- Time Us -->
+                        <!-- custom -->
                         <bibl><publisher>Time Us</publisher> (<date>2017-2020</date>) : http://timeusage.paris.inria.fr/mediawiki/index.php/Accueil</bibl>
-                        <!-- fin Time Us -->
+                        <!-- end custom -->
                     </publicationStmt>
                     <sourceDesc>
                         <p><xsl:value-of select="p:Metadata/temp:desc"/></p>
                     </sourceDesc>
                 </fileDesc>
                 <encodingDesc>
-                    <!-- Time Us -->
+                    <!-- custom -->
                     <projectDesc>TIME US est un projet ANR dont le but est de reconstituer les rémunérations et les budgets temps des travailleur⋅ses du textile dans quatre villes industrielles française (Lille, Paris, Lyon, Marseille) dans une perspective européenne et de longue durée. Il réunit une équipe pluridisciplinaire d'historiens des techniques, de l'économie et du travail, des spécialistes du traitement automatique des langues et des sociologues spécialistes des budgets familiaux. Il vise à donner des clés pour comprendre le gender gap en analysant les mutations du travail et la répartition du temps et des tâches au sein des ménages pendant la première industrialisation. Pour ce faire, le projet met en place une action de transcription et d'annotation de documents d'archives datés de la fin du XVIIe au début du XXe siècle.</projectDesc>
                     <editorialDecl>
                         <p>Les transcriptions et leur annotations sont réalisées à l'aide de la plate-forme Transkribus.</p>
                         <p>Statut de la transcription lors de son export : "<xsl:value-of select="p:Metadata/temp:tsStatus"/>".</p>
                     </editorialDecl>
-                    <!-- fin Time Us -->
+                    <!-- end custom -->
                 </encodingDesc>
                 <xsl:if test="count(p:Metadata/temp:language) &gt; 0">
                     <profileDesc>
@@ -419,7 +419,7 @@
                 </orgName>
             </xsl:when>
 
-            <!-- TIME US TAGS -->
+            <!-- CUSTOM TAGS -->
             <xsl:when test="@type = 'TU_remuneration'">
                 <rs>
                     <xsl:attribute name="type">revenue</xsl:attribute>
@@ -610,7 +610,7 @@
                 </xsl:call-template>
                 <xsl:comment><xsl:value-of select="replace(replace(replace(map:get($custom, 'comment'), '\\u0020', ' '), '\\u0027', ''''), '\\u0022', '&quot;')"/></xsl:comment>
             </xsl:when>
-            <!-- END OF TIME US TAGS -->
+            <!-- END OF CUSTOM TAGS -->
 
             <xsl:otherwise>
                 <xsl:element name="{@type}">

--- a/page2tei_TU.xsl
+++ b/page2tei_TU.xsl
@@ -7,7 +7,8 @@
     xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:map="http://www.w3.org/2005/xpath-functions/map" xmlns:local="local"
     xmlns:xstring="https://github.com/dariok/XStringUtils" exclude-result-prefixes="#all"
-    xmlns:tu="timeUs" version="3.0">
+    xmlns:tu="timeUs" 
+    xmlns:temp="temporary" version="3.0">
 
     <xd:doc scope="stylesheet">
         <xd:desc>

--- a/page2tei_TU.xsl
+++ b/page2tei_TU.xsl
@@ -56,7 +56,10 @@
                 <encodingDesc>
                     <!-- Time Us -->
                     <projectDesc>TIME US est un projet ANR dont le but est de reconstituer les rémunérations et les budgets temps des travailleur⋅ses du textile dans quatre villes industrielles française (Lille, Paris, Lyon, Marseille) dans une perspective européenne et de longue durée. Il réunit une équipe pluridisciplinaire d'historiens des techniques, de l'économie et du travail, des spécialistes du traitement automatique des langues et des sociologues spécialistes des budgets familiaux. Il vise à donner des clés pour comprendre le gender gap en analysant les mutations du travail et la répartition du temps et des tâches au sein des ménages pendant la première industrialisation. Pour ce faire, le projet met en place une action de transcription et d'annotation de documents d'archives datés de la fin du XVIIe au début du XXe siècle.</projectDesc>
-                    <editorialDecl>Les transcriptions et leur annotations sont réalisées à l'aide de la plate-forme Transkribus.</editorialDecl>
+                    <editorialDecl>
+                        <p>Les transcriptions et leur annotations sont réalisées à l'aide de la plate-forme Transkribus.</p>
+                        <p>Statut de la transcription lors de son export : "<xsl:value-of select="p:Metadata/temp:tsStatus"/>".</p>
+                    </editorialDecl>
                     <!-- fin Time Us -->
                 </encodingDesc>
                 <xsl:if test="count(p:Metadata/temp:language) &gt; 0">

--- a/page2tei_TU.xsl
+++ b/page2tei_TU.xsl
@@ -74,43 +74,15 @@
                     <change type="ToTEI"><xsl:value-of select="current-dateTime()"/></change>
                 </revisionDesc>
             </teiHeader>
-            <!-- NEED CHANGE : only Page as starting bloc -->
             <xsl:if test="not($debug)">
-                <xsl:choose>
-                    <xsl:when test="p:Page">
-                        <xsl:apply-templates select="p:Page" mode="facsimile"/>
-                    </xsl:when>
-                    <!-- NNED CHANGE remove this option -->
-                    <xsl:when test="tu:PageGrp">
-                        <xsl:apply-templates select="tu:PageGrp" mode="facsimile"/>
-                    </xsl:when>
-                </xsl:choose>
+                <xsl:apply-templates select="p:Page" mode="facsimile"/>
             </xsl:if>
             <text>
                 <body>
-                    <!-- NEED CHANGE only Page as starting block -->
-                    <xsl:choose>
-                        <xsl:when test="p:Page">
-                            <xsl:apply-templates select="p:Page" mode="text"/>
-                        </xsl:when>
-                        <!-- NEED CHANGE remove this option -->
-                        <xsl:when test="tu:PageGrp">
-                            <xsl:apply-templates select="tu:PageGrp" mode="text"/>
-                        </xsl:when>
-                    </xsl:choose>
+                    <xsl:apply-templates select="p:Page" mode="text"></xsl:apply-templates>
                 </body>
             </text>
         </TEI>
-    </xsl:template>
-
-
-    <!-- NEED CHANGE -->
-    <!-- Templates for PAGE, facsimile -->
-    <xd:doc>
-        <xd:p>Create tei:facsimile</xd:p>
-    </xd:doc>
-    <xsl:template match="tu:PageGrp" mode="fascimile">
-        <xsl:apply-templates select="p:Page" mode="facsimile"/>
     </xsl:template>
 
     <xd:doc>
@@ -189,14 +161,6 @@
             </xsl:if>
 
         </zone>
-    </xsl:template>
-
-    <!-- NEED CHANGE -->
-    <xd:doc>
-        <xd:p>create page content</xd:p>
-    </xd:doc>
-    <xsl:template match="tu:PageGrp" mode="text">
-        <xsl:apply-templates select="p:Page" mode="text"/>
     </xsl:template>
 
     <xd:doc>

--- a/page2tei_TU.xsl
+++ b/page2tei_TU.xsl
@@ -8,7 +8,7 @@
     xmlns:map="http://www.w3.org/2005/xpath-functions/map" xmlns:local="local"
     xmlns:xstring="https://github.com/dariok/XStringUtils" exclude-result-prefixes="#all"
     xmlns:tu="timeUs" 
-    xmlns:temp="temporary" version="3.0">
+    xmlns:temp="temporary" version="2.0">
 
     <xd:doc scope="stylesheet">
         <xd:desc>

--- a/page2tei_TU.xsl
+++ b/page2tei_TU.xsl
@@ -36,27 +36,33 @@
             <teiHeader>
                 <fileDesc>
                     <titleStmt>
-                        <title><xsl:value-of select="p:Metadata/tu:title"/><xsl:choose>
-                            <xsl:when test="p:Page">, page <xsl:value-of select="p:Metadata/tu:pagenumber"/></xsl:when>
+                        <title><xsl:value-of select="p:Metadata/temp:title"/><xsl:choose>
+                            <xsl:when test="p:Page">, page <xsl:value-of select="p:Metadata/temp:pagenumber"/></xsl:when>
                         </xsl:choose> - Transcription</title>
+                        <!-- Time Us -->
                         <editor>Manuela Martini</editor>
-                        <respStmt><name><xsl:value-of select="p:Metadata/tu:uploader"/></name>, <resp>créateur⋅rice du document Transkribus (TRP).</resp></respStmt>
+                        <!-- fin Time Us -->
+                        <respStmt><name><xsl:value-of select="p:Metadata/temp:uploader"/></name>, <resp>créateur⋅rice du document Transkribus (TRP).</resp></respStmt>
                     </titleStmt>
                     <publicationStmt>
+                        <!-- Time Us -->
                         <bibl><publisher>Time Us</publisher> (<date>2017-2020</date>) : http://timeusage.paris.inria.fr/mediawiki/index.php/Accueil</bibl>
+                        <!-- fin Time Us -->
                     </publicationStmt>
                     <sourceDesc>
-                        <p><xsl:value-of select="p:Metadata/tu:desc"/></p>
+                        <p><xsl:value-of select="p:Metadata/temp:desc"/></p>
                     </sourceDesc>
                 </fileDesc>
                 <encodingDesc>
+                    <!-- Time Us -->
                     <projectDesc>TIME US est un projet ANR dont le but est de reconstituer les rémunérations et les budgets temps des travailleur⋅ses du textile dans quatre villes industrielles française (Lille, Paris, Lyon, Marseille) dans une perspective européenne et de longue durée. Il réunit une équipe pluridisciplinaire d'historiens des techniques, de l'économie et du travail, des spécialistes du traitement automatique des langues et des sociologues spécialistes des budgets familiaux. Il vise à donner des clés pour comprendre le gender gap en analysant les mutations du travail et la répartition du temps et des tâches au sein des ménages pendant la première industrialisation. Pour ce faire, le projet met en place une action de transcription et d'annotation de documents d'archives datés de la fin du XVIIe au début du XXe siècle.</projectDesc>
                     <editorialDecl>Les transcriptions et leur annotations sont réalisées à l'aide de la plate-forme Transkribus.</editorialDecl>
+                    <!-- fin Time Us -->
                 </encodingDesc>
-                <xsl:if test="count(p:Metadata/tu:language) &gt; 0">
+                <xsl:if test="count(p:Metadata/temp:language) &gt; 0">
                     <profileDesc>
                         <langUsage>
-                            <xsl:for-each select="p:Metadata/tu:language">
+                            <xsl:for-each select="p:Metadata/temp:language">
                                 <language><xsl:value-of select="."/></language>
                             </xsl:for-each>
                         </langUsage>
@@ -68,11 +74,13 @@
                     <change type="ToTEI"><xsl:value-of select="current-dateTime()"/></change>
                 </revisionDesc>
             </teiHeader>
+            <!-- NEED CHANGE : only Page as starting bloc -->
             <xsl:if test="not($debug)">
                 <xsl:choose>
                     <xsl:when test="p:Page">
                         <xsl:apply-templates select="p:Page" mode="facsimile"/>
                     </xsl:when>
+                    <!-- NNED CHANGE remove this option -->
                     <xsl:when test="tu:PageGrp">
                         <xsl:apply-templates select="tu:PageGrp" mode="facsimile"/>
                     </xsl:when>
@@ -80,10 +88,12 @@
             </xsl:if>
             <text>
                 <body>
+                    <!-- NEED CHANGE only Page as starting block -->
                     <xsl:choose>
                         <xsl:when test="p:Page">
                             <xsl:apply-templates select="p:Page" mode="text"/>
                         </xsl:when>
+                        <!-- NEED CHANGE remove this option -->
                         <xsl:when test="tu:PageGrp">
                             <xsl:apply-templates select="tu:PageGrp" mode="text"/>
                         </xsl:when>
@@ -94,7 +104,7 @@
     </xsl:template>
 
 
-
+    <!-- NEED CHANGE -->
     <!-- Templates for PAGE, facsimile -->
     <xd:doc>
         <xd:p>Create tei:facsimile</xd:p>
@@ -107,8 +117,8 @@
         <xd:p>Create tei:surface and tei:graphic</xd:p>
     </xd:doc>
     <xsl:template match="p:Page" mode="facsimile">
-        <xsl:variable name="url" select="@tu:url"/>
-        <xsl:variable name="numCurr" select="@tu:id"/>
+        <xsl:variable name="url" select="@temp:urltoimg"/>
+        <xsl:variable name="numCurr" select="@temp:id"/>
         <xsl:variable name="imageName" select="@imageFilename"/>
         <xsl:variable name="type" select="substring-after(@imageFilename, '.')"/>
 
@@ -181,6 +191,7 @@
         </zone>
     </xsl:template>
 
+    <!-- NEED CHANGE -->
     <xd:doc>
         <xd:p>create page content</xd:p>
     </xd:doc>


### PR DESCRIPTION
Revision of the XSL transformation to match ExportFromTranskribus script.

Changes are :
- namespace changed from `tu` (timeUs) to `temp` (temporary) in source file
- no more choice between `p:Page` and `p:PageGrp` (transformation is intended to run on files as they are exported from Transkribus, except for metadata additions under temporary namespace)
- clearer signal of XSL parts customed for specific projects
